### PR TITLE
Add support for Rust 1.56.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.56.1
 sudo: false
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["size", "formatting", "humanize", "file-size"]
 categories = ["value-formatting"]
 license = "MIT/Apache-2.0"
 exclude = ["/feature-tests"]
+rust-version = "1.56"
 
 [features]
 no_alloc = []

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -4,14 +4,19 @@
 mod defaults;
 pub use self::defaults::*;
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 /// Holds the standard to use when displaying the size.
 pub enum Kilo {
     /// The decimal scale and units. SI standard.
-    #[default]
     Decimal,
     /// The binary scale and units.
     Binary,
+}
+
+impl Default for Kilo {
+    fn default() -> Self {
+        Self::Decimal
+    }
 }
 
 impl Kilo {
@@ -37,11 +42,16 @@ pub enum FixedAt {
     Yotta,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum BaseUnit {
     Bit,
-    #[default]
     Byte,
+}
+
+impl Default for BaseUnit {
+    fn default() -> Self {
+        Self::Byte
+    }
 }
 
 /// Holds the options for the `file_size` method.


### PR DESCRIPTION
#[derive(Default)] requires Rust 1.62.0, so we reimplement Default trait manualy to support older Rust versions.

Fixes #25 