### PR TITLE
Constify FormatSizeOptions

### DIFF
--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -119,51 +119,51 @@ pub struct FormatSizeOptions {
 }
 
 impl FormatSizeOptions {
-    pub fn from(from: FormatSizeOptions) -> FormatSizeOptions {
+    pub const fn from(from: FormatSizeOptions) -> FormatSizeOptions {
         FormatSizeOptions { ..from }
     }
 
-    pub fn base_unit(mut self, base_unit: BaseUnit) -> FormatSizeOptions {
+    pub const fn base_unit(mut self, base_unit: BaseUnit) -> FormatSizeOptions {
         self.base_unit = base_unit;
         self
     }
 
-    pub fn kilo(mut self, kilo: Kilo) -> FormatSizeOptions {
+    pub const fn kilo(mut self, kilo: Kilo) -> FormatSizeOptions {
         self.kilo = kilo;
         self
     }
 
-    pub fn units(mut self, units: Kilo) -> FormatSizeOptions {
+    pub const fn units(mut self, units: Kilo) -> FormatSizeOptions {
         self.units = units;
         self
     }
 
-    pub fn decimal_places(mut self, decimal_places: usize) -> FormatSizeOptions {
+    pub const fn decimal_places(mut self, decimal_places: usize) -> FormatSizeOptions {
         self.decimal_places = decimal_places;
         self
     }
 
-    pub fn decimal_zeroes(mut self, decimal_zeroes: usize) -> FormatSizeOptions {
+    pub const fn decimal_zeroes(mut self, decimal_zeroes: usize) -> FormatSizeOptions {
         self.decimal_zeroes = decimal_zeroes;
         self
     }
 
-    pub fn fixed_at(mut self, fixed_at: Option<FixedAt>) -> FormatSizeOptions {
+    pub const fn fixed_at(mut self, fixed_at: Option<FixedAt>) -> FormatSizeOptions {
         self.fixed_at = fixed_at;
         self
     }
 
-    pub fn long_units(mut self, long_units: bool) -> FormatSizeOptions {
+    pub const fn long_units(mut self, long_units: bool) -> FormatSizeOptions {
         self.long_units = long_units;
         self
     }
 
-    pub fn space_after_value(mut self, insert_space: bool) -> FormatSizeOptions {
+    pub const fn space_after_value(mut self, insert_space: bool) -> FormatSizeOptions {
         self.space_after_value = insert_space;
         self
     }
 
-    pub fn suffix(mut self, suffix: &'static str) -> FormatSizeOptions {
+    pub const fn suffix(mut self, suffix: &'static str) -> FormatSizeOptions {
         self.suffix = suffix;
         self
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,92 +17,108 @@ fn test_sizes() {
     assert_eq!(format_size_i(1000f64, DECIMAL), "1 kB");
 
 
-    let custom_options = FormatSizeOptions::from(DECIMAL).space_after_value(false);
-    assert_eq!(format_size(1000u32, custom_options), "1kB");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL).space_after_value(false);
+        assert_eq!(format_size(1000u32, CUSTOM_OPTIONS), "1kB");
+    }
 
-    let custom_options = FormatSizeOptions::from(BINARY).suffix("/s");
-    assert_eq!(format_size(999u32, custom_options), "999 B/s");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY).suffix("/s");
+        assert_eq!(format_size(999u32, CUSTOM_OPTIONS), "999 B/s");
+    }
 
-    let custom_options = FormatSizeOptions::from(DECIMAL)
-        .suffix("/day")
-        .space_after_value(false);
-    assert_eq!(format_size(1000u32, custom_options), "1kB/day");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL)
+            .suffix("/day")
+            .space_after_value(false);
+        assert_eq!(format_size(1000u32, CUSTOM_OPTIONS), "1kB/day");
+    }
 
-    let custom_options = FormatSizeOptions::from(BINARY).fixed_at(Some(FixedAt::Base));
-    assert_eq!(format_size(2048u32, custom_options), "2048 B");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY).fixed_at(Some(FixedAt::Base));
+        assert_eq!(format_size(2048u32, CUSTOM_OPTIONS), "2048 B");
+    }
 
-    let custom_options = FormatSizeOptions::from(BINARY)
-        .fixed_at(Some(FixedAt::Base))
-        .long_units(true);
-    assert_eq!(format_size(2048u32, custom_options), "2048 Bytes");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY)
+            .fixed_at(Some(FixedAt::Base))
+            .long_units(true);
+        assert_eq!(format_size(2048u32, CUSTOM_OPTIONS), "2048 Bytes");
+    }
 
-    let custom_options = FormatSizeOptions::from(BINARY).fixed_at(Some(FixedAt::Kilo));
-    assert_eq!(format_size(16584975u32, custom_options), "16196.26 KiB");
-    assert_eq!(format_size_i(-16584975, custom_options), "-16196.26 KiB");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY).fixed_at(Some(FixedAt::Kilo));
+        assert_eq!(format_size(16584975u32, CUSTOM_OPTIONS), "16196.26 KiB");
+        assert_eq!(format_size_i(-16584975, CUSTOM_OPTIONS), "-16196.26 KiB");
+    }
 
-    let custom_options = FormatSizeOptions::from(BINARY)
-        .fixed_at(Some(FixedAt::Tera))
-        .decimal_places(10);
-    assert_eq!(format_size(15284975u32, custom_options), "0.0000139016 TiB");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY)
+            .fixed_at(Some(FixedAt::Tera))
+            .decimal_places(10);
+        assert_eq!(format_size(15284975u32, CUSTOM_OPTIONS), "0.0000139016 TiB");
 
-    assert_eq!((format_size_i(-5500, DECIMAL)), "-5.50 kB");
-    assert_eq!((format_size(5500u32, DECIMAL)), "5.50 kB");
+        assert_eq!((format_size_i(-5500, DECIMAL)), "-5.50 kB");
+        assert_eq!((format_size(5500u32, DECIMAL)), "5.50 kB");
+    }
 
-    let custom_options = FormatSizeOptions::from(DECIMAL).base_unit(BaseUnit::Bit);
-    assert_eq!((format_size(1usize, custom_options)), "1 bit");
-    assert_eq!((format_size(150usize, custom_options)), "150 bits");
-    assert_eq!((format_size(1000usize, custom_options)), "1 kbit");
+    {
+        const CUSTOM_OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL).base_unit(BaseUnit::Bit);
+        assert_eq!((format_size(1usize, CUSTOM_OPTIONS)), "1 bit");
+        assert_eq!((format_size(150usize, CUSTOM_OPTIONS)), "150 bits");
+        assert_eq!((format_size(1000usize, CUSTOM_OPTIONS)), "1 kbit");
+    }
 }
 
 #[test]
 fn use_custom_option_struct_twice() {
-    let options = FormatSizeOptions::from(DECIMAL).long_units(true);
+    const OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL).long_units(true);
 
-    assert_eq!(format_size(1500u32, &options), "1.50 Kilobyte",);
-    assert_eq!(format_size(2500u32, &options), "2.50 Kilobytes",);
-    assert_eq!(format_size_i(-2500000, &options), "-2.50 Megabytes",);
+    assert_eq!(format_size(1500u32, &OPTIONS), "1.50 Kilobyte",);
+    assert_eq!(format_size(2500u32, &OPTIONS), "2.50 Kilobytes",);
+    assert_eq!(format_size_i(-2500000, &OPTIONS), "-2.50 Megabytes",);
 }
 
 #[test]
 fn pluralization_works() {
-    let options = FormatSizeOptions::from(DECIMAL)
+    const OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL)
         .long_units(true)
         .decimal_zeroes(2);
 
-    assert_eq!(format_size(1u32, &options), "1.00 Byte",);
+    assert_eq!(format_size(1u32, &OPTIONS), "1.00 Byte",);
 
-    assert_eq!(format_size(1000u32, &options), "1.00 Kilobyte",);
+    assert_eq!(format_size(1000u32, &OPTIONS), "1.00 Kilobyte",);
 
-    assert_eq!(format_size(1000000u32, &options), "1.00 Megabyte",);
+    assert_eq!(format_size(1000000u32, &OPTIONS), "1.00 Megabyte",);
 
-    assert_eq!(format_size(1000000000u32, &options), "1.00 Gigabyte",);
+    assert_eq!(format_size(1000000000u32, &OPTIONS), "1.00 Gigabyte",);
 
-    assert_eq!(format_size_i(1000000000000_i64, &options), "1.00 Terabyte",);
+    assert_eq!(format_size_i(1000000000000_i64, &OPTIONS), "1.00 Terabyte",);
 
     assert_eq!(
-        format_size_i(1000000000000000_i64, &options),
+        format_size_i(1000000000000000_i64, &OPTIONS),
         "1.00 Petabyte",
     );
 
     assert_eq!(
-        format_size_i(1000000000000000000_i64, &options),
+        format_size_i(1000000000000000000_i64, &OPTIONS),
         "1.00 Exabyte",
     );
 }
 
 #[test]
 fn max_value_decimal() {
-    let options = FormatSizeOptions::from(DECIMAL)
+    const OPTIONS: FormatSizeOptions = FormatSizeOptions::from(DECIMAL)
         .decimal_places(7)
         .long_units(true);
-    assert_eq!(format_size(core::u64::MAX, &options), "18.4467441 Exabytes",);
+    assert_eq!(format_size(core::u64::MAX, &OPTIONS), "18.4467441 Exabytes",);
 }
 
 #[test]
 fn max_value_binary() {
-    let options = FormatSizeOptions::from(BINARY)
+    const OPTIONS: FormatSizeOptions = FormatSizeOptions::from(BINARY)
         .decimal_places(7)
         .long_units(true);
 
-    assert_eq!(format_size(core::u64::MAX, &options), "16 Exbibytes",);
+    assert_eq!(format_size(core::u64::MAX, &OPTIONS), "16 Exbibytes",);
 }


### PR DESCRIPTION
Allow creating `const FormatSizeOptions` - as the tests now do for example.