### PR TITLE
README typo in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Enabling this feature makes two methods available:
 
 To use it, bring the FormatSize trait into scope and call its method on an integer type:
 ```ignore
-use humansize::{FormatSize, FormatSizeI DECIMAL};
+use humansize::{FormatSize, DECIMAL};
 
 assert_eq!(1_000_000u64.format_size(DECIMAL), "1 MB");
 assert_eq!((-1_000_000).format_size_i(DECIMAL), "-1 MB");


### PR DESCRIPTION
Not sure how this ended up in there (too much vim?) and not 100% confident my fix is correct, I'm doing this as a drive-by from the GitHub web UI, but the original didn't sound right.